### PR TITLE
add basic support for @supports statements

### DIFF
--- a/mapcss_parser/ast.py
+++ b/mapcss_parser/ast.py
@@ -4,6 +4,8 @@
 MapCSS data model. This is "as is" object representation of MapCSS file
 """
 
+import re
+
 def is_number(s):
     try:
         float(s)
@@ -208,3 +210,77 @@ class EvalFunction:
 
     def __str__(self):
         return "%s(%s)" % (self.function, ", ".join(map(str, self.arguments)))
+
+class Supports:
+    def __init__(self, conditions):
+        self.conditions = conditions
+
+    def __str__(self):
+        return "@supports"
+
+    def value(self):
+        return self.conditions.value()
+
+class SupportsAnd:
+    def __init__(self, condA, condB):
+        self.condA = condA
+        self.condB = condB
+
+    def __str__(self):
+        return "(%s) AND (%s)" % (self.condA, self.condB)
+
+    def value(self):
+        if not self.condA.value():
+            return False
+
+        return self.condB.value()
+
+class SupportsOr:
+    def __init__(self, condA, condB):
+        self.condA = condA
+        self.condB = condB
+
+    def __str__(self):
+        return "(%s) OR (%s)" % (self.condA, self.condB)
+
+    def value(self):
+        if self.condA.value():
+            return True
+
+        return self.condB.value()
+
+class SupportsNot:
+    def __init__(self, cond):
+        self.cond = cond
+
+    def __str__(self):
+        return "NOT (%s)" % self.cond
+
+    def value(self):
+        return not self.cond.value()
+
+class SupportsCondition:
+    def __init__(self, cond):
+        self.cond = cond
+
+    def __str__(self):
+        return "%s" % self.cond
+
+    def value(self):
+        return self.cond.value()
+
+class SupportsDecl:
+    def __init__(self, condition):
+        self.cond = condition
+
+    def __str__(self):
+        return "%s" % self.cond
+
+    def value(self):
+        if re.search(r'user-agent[ \t]*:[ \t]*kothic-js', self.cond):
+            return True
+        return False
+
+class SupportsEnd:
+    def __str__(self):
+        return "}"

--- a/mapcss_parser/lex.py
+++ b/mapcss_parser/lex.py
@@ -21,6 +21,9 @@ states = (
     ('tagvalue', 'exclusive'),
     ('import', 'exclusive'),
     ('eval', 'exclusive'),
+    ('supportssel', 'exclusive'),
+    ('supportsselparen', 'inclusive'),
+    ('supportscontent', 'inclusive'),
 )
 
 tokens = (
@@ -71,6 +74,17 @@ tokens = (
     'NUMBER',
     'OPERATION',
     'FUNCTION',
+
+    #@supports
+    'SUPPORTS',
+    'SUP_LCBRACE',
+    'SUP_RCBRACE',
+    'SUP_LPAREN',
+    'SUP_RPAREN',
+    'SUP_NOT',
+    'SUP_OR',
+    'SUP_AND',
+    'SUP_STATEMENT',
 )
 
 # Completely ignored characters
@@ -91,6 +105,10 @@ t_eval_NUMBER = r'\d+(\.\d+)?'
 t_eval_OPERATION = r'\+|-|\*|\/|==|<>|!=|<=|>=|>|<|eq|ne|\.'
 t_eval_FUNCTION = r'\w+'
 t_eval_COMMA = r','
+
+t_supportssel_SUP_NOT = '[Nn][Oo][Tt]'
+t_supportssel_SUP_OR = '[Oo][Rr]'
+t_supportssel_SUP_AND = '[Aa][Nn][Dd]'
 
 def t_ANY_CXXCOMMENT(t):
     r'//[^\n]*'
@@ -235,6 +253,37 @@ def t_regex_REGEX_BODY(t):
 def t_condition_RSQBRACE(t):
     r'\]'
     t.lexer.pop_state()
+    return t
+
+def t_SUPPORTS(t):
+    r'@supports'
+    t.lexer.push_state('supportssel')
+    return t
+
+def t_supportssel_SUP_LCBRACE(t):
+    r'{'
+    t.lexer.pop_state()
+    t.lexer.push_state('supportscontent')
+    return t
+
+def t_supportscontent_SUP_RCBRACE(t):
+    r'}'
+    t.lexer.pop_state()
+    return t
+
+def t_supportssel_SUP_LPAREN(t):
+    r'\('
+    t.lexer.push_state('supportsselparen')
+    return t
+
+def t_supportsselparen_SUP_RPAREN(t):
+    r'\)'
+    t.lexer.pop_state()
+    return t
+
+# this is incomplete, but should work for now
+def t_supportsselparen_SUP_STATEMENT(t):
+    r'[^(){}\n]+(\([^(){}]*\)\n)*[^(){}\n]*'
     return t
 
 # Error handling rule

--- a/mapcss_parser/parse.py
+++ b/mapcss_parser/parse.py
@@ -22,6 +22,11 @@ def p_mapcss_import(p):
     p[0] = ast.MapCSS()
     p[0].append_import(p[1])
 
+def p_mapcss_supports(p):
+    'css : supports'
+    p[0] = ast.MapCSS()
+    p[0].append_rule(p[1])
+
 def p_mapcss_multiple_rules(p):
     'css : css rule'
     p[0] = p[1]
@@ -31,6 +36,11 @@ def p_mapcss_multiple_imports(p):
     'css : css import'
     p[0] = p[1]
     p[0].append_import(p[2])
+
+def p_mapcss_multiple_supports(p):
+    'css : css supports'
+    p[0] = p[1]
+    p[0].append_rule(p[2])
 
 def p_import_pseudoclass(p):
     'import : IMPORT URL PSEUDOCLASS SEMICOLON'
@@ -198,5 +208,58 @@ def p_eval_function_argument_multiple(p):
 def p_eval_function(p):
     'eval_function : FUNCTION LPAREN function_argument RPAREN'
     p[0] = ast.EvalFunction(p[1], p[3])
+
+def p_supports_condition_neg(p):
+    'sup_condition : sup_negation'
+    p[0] = ast.SupportsCondition(p[1])
+
+def p_supports_condition_conj(p):
+    'sup_condition : sup_conjunction'
+    p[0] = ast.SupportsCondition(p[1])
+
+def p_supports_condition_disj(p):
+    'sup_condition : sup_disjunction'
+    p[0] = ast.SupportsCondition(p[1])
+
+def p_supports_condition_parens(p):
+    'sup_condition : sup_cond_parens'
+    p[0] = ast.SupportsCondition(p[1])
+
+def p_supports_negation(p):
+    'sup_negation : SUP_NOT sup_cond_parens'
+    p[0] = ast.SupportsNot(p[2])
+
+def p_supports_conjunction(p):
+    'sup_conjunction : sup_cond_parens SUP_AND sup_cond_parens'
+    p[0] = ast.SupportsAnd(p[1], p[3])
+
+def p_supports_multiple_conjunction(p):
+    'sup_conjunction : sup_conjunction SUP_AND sup_cond_parens'
+    p[0] = ast.SupportsAnd(p[1], p[3])
+
+def p_supports_disjunction(p):
+    'sup_disjunction : sup_cond_parens SUP_OR sup_cond_parens'
+    p[0] = ast.SupportsOr(p[1], p[3])
+
+def p_supports_multiple_disjunction(p):
+    'sup_disjunction : sup_disjunction SUP_OR sup_cond_parens'
+    p[0] = ast.SupportsOr(p[1], p[3])
+
+def p_supports_parens(p):
+    'sup_cond_parens : SUP_LPAREN sup_condition SUP_RPAREN'
+    p[0] = p[2]
+
+def p_support_decl_condition(p):
+    'sup_cond_parens : SUP_LPAREN SUP_STATEMENT SUP_RPAREN'
+    p[0] = ast.SupportsDecl(p[2])
+
+def p_supports(p):
+    'supports : SUPPORTS sup_condition SUP_LCBRACE'
+    p[0] = ast.Supports(p[2])
+
+def p_supports_end(p):
+    'css : css SUP_RCBRACE'
+    p[0] = p[1]
+    p[0].append_rule(ast.SupportsEnd())
 
 yacc.yacc(debug=0)


### PR DESCRIPTION
The only statement that is correctly evaluated and returns true is "user-agent:kothic-js". Otherwise only the logical operators work as specified.

Extra parentheses are currently not working, but this should be ok for now.
