### PR TITLE
Use exceptions to flag MapCSS errors

### DIFF
--- a/mapcss_parser/ast.py
+++ b/mapcss_parser/ast.py
@@ -4,6 +4,8 @@
 MapCSS data model. This is "as is" object representation of MapCSS file
 """
 
+from mapcss_parser import error
+
 def is_number(s):
     try:
         float(s)
@@ -150,6 +152,8 @@ class ConditionCheck:
         self.key = key
         self.sign = sign
         self.value = value
+        if ((sign == '!~' or sign == '=~') and (value[0:1] != '/' or value[-1:] != '/')):
+            raise error.MapCSSError("regular expression operator %s used with operand '%s' that is no regular expression" % (sign, value))
 
     def __str__(self):
         return "[%s%s%s]" % (self.key, self.sign, self.value)

--- a/mapcss_parser/error.py
+++ b/mapcss_parser/error.py
@@ -1,0 +1,4 @@
+#!/usr/bin/python
+
+class MapCSSError(Exception):
+    pass

--- a/mapcss_parser/lex.py
+++ b/mapcss_parser/lex.py
@@ -4,6 +4,7 @@
 
 import re
 import ply.lex as lex
+from mapcss_parser import error
 
 # Compute column.
 #     input is the input text string
@@ -239,8 +240,7 @@ def t_condition_RSQBRACE(t):
 
 # Error handling rule
 def t_ANY_error(t):
-    print("Illegal character '%s' at line %i position %i" % (t.value[0], t.lexer.lineno, find_column(t.lexer.lexdata, t)))
-    t.lexer.skip(1)
+    raise error.MapCSSError("Illegal character '%s' at line %i position %i" % (t.value[0], t.lexer.lineno, find_column(t.lexer.lexdata, t)))
 
 # Define a rule so we can track line numbers
 def t_ANY_newline(t):


### PR DESCRIPTION
Ignoring them can lead to either even more errors, or a file that is missing important parts. Use an exception so the caller can decide how to handle those errors.
